### PR TITLE
trigger combat log when an entity or block explodes

### DIFF
--- a/src/main/java/net/badbird5907/anticombatlog/AntiCombatLog.java
+++ b/src/main/java/net/badbird5907/anticombatlog/AntiCombatLog.java
@@ -34,7 +34,7 @@ import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.util.*;
 
-public final class AntiCombatLog extends JavaPlugin { //TODO config editor in game
+public final class  AntiCombatLog extends JavaPlugin { //TODO config editor in game
     @Getter
     @Setter
     private static Map<UUID, Integer> inCombatTag = new HashMap<>(); //might do async idk
@@ -112,6 +112,23 @@ public final class AntiCombatLog extends JavaPlugin { //TODO config editor in ga
             victim.sendMessage(StringUtils.format(ConfigValues.getCombatTaggedMessage(), ConfigValues.getCombatTagSeconds() + ""));
         if (sendMessageAttacker)
             attacker.sendMessage(StringUtils.format(ConfigValues.getCombatTaggedMessage(), ConfigValues.getCombatTagSeconds() + ""));
+    }
+
+    public static void tagSingle(Player victim) {
+        if (victim.getGameMode() == GameMode.CREATIVE)
+            return;
+        CombatTagEvent event = new CombatTagEvent(victim, victim);
+        Bukkit.getPluginManager().callEvent(event);
+        if (event.isCancelled())
+            return;
+        boolean sendMessageVictim = true;
+        if (inCombatTag.containsKey(victim.getUniqueId())) {
+            inCombatTag.remove(victim.getUniqueId());
+            sendMessageVictim = false;
+        }
+        inCombatTag.put(victim.getUniqueId(), ConfigValues.getCombatTagSeconds());
+        if (sendMessageVictim)
+            victim.sendMessage(StringUtils.format(ConfigValues.getCombatTaggedMessage(), ConfigValues.getCombatTagSeconds() + ""));
     }
 
     public static void disconnect(Player player) {

--- a/src/main/java/net/badbird5907/anticombatlog/listener/CombatListener.java
+++ b/src/main/java/net/badbird5907/anticombatlog/listener/CombatListener.java
@@ -16,9 +16,21 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
 public class CombatListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onGenericDamageExplode(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player)) { return; }
+        Player player = (Player) event.getEntity();
+        if (event.getCause() == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION || event.getCause() == EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) {
+            // cover explosions by entities (e.g. crystals, creepers) and blocks (e.g. anchors)
+            AntiCombatLog.tagSingle(player);
+        }
+    }
+
     @EventHandler(priority = EventPriority.MONITOR)
     public void onDamage(EntityDamageByEntityEvent event) {
         if (event.isCancelled() || event.getFinalDamage() <= 0)


### PR DESCRIPTION
this PR triggers a combat log tag whenever a player is damaged by an explosion by a block or entity, intended to disallow players from logging out of end crystals, anchors, beds, creepers, etc